### PR TITLE
Correctly check for resetusertours setting.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2019-01-05 - Bugfix: Corrected check for the user tours setting.
 * 2018-12-05 - Changed travis.yml due to upstream changes.
 
 ### Release v3.5-r1

--- a/lib.php
+++ b/lib.php
@@ -153,7 +153,7 @@ function local_navbarplus_render_navbar_output() {
         }
     }
     // If setting resetuseertours is enabled.
-    if (isset($config->resetusertours)) {
+    if (isset($config->resetusertours) && $config->resetusertours == true) {
         if (isloggedin() || !isguestuser()) {
             // Get the tour for the current page.
             $tour = \tool_usertours\manager::get_current_tour();


### PR DESCRIPTION
You'll notice otherwise the setting isn't making any difference and the reset user tours map icons will always be displayed in the navbar no matter what checkbox state in the configuration UI.

Best,
Luca