### PR TITLE
13: Fix undefined method get_current_tour()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ php:
 
 env:
  global:
-  - MOODLE_BRANCH=MOODLE_39_STABLE
+  - MOODLE_BRANCH=MOODLE_310_STABLE
  matrix:
   - DB=pgsql
   - DB=mysqli

--- a/lib.php
+++ b/lib.php
@@ -160,7 +160,7 @@ function local_navbarplus_render_navbar_output() {
     if (isset($config->resetusertours) && $config->resetusertours == true) {
         if (isloggedin() || !isguestuser()) {
             // Get the tour for the current page.
-            $tour = \tool_usertours\manager::get_current_tour();
+            $tour = \tool_usertours\manager::get_current_tours();
             if (!empty($tour)) {
                 // Open div.
                 $output .= html_writer::start_tag('div', array('class' => 'localnavbarplus nav-link',

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_navbarplus';
-$plugin->version = 2020071700;
-$plugin->release = 'v3.9-r1';
-$plugin->requires = 2020061500;
+$plugin->version = 2020122300;
+$plugin->release = 'v3.10-r1';
+$plugin->requires = 2020110900;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
In Moodle 3.10 tool_usertours\manager::get_current_tour() was renamed
tool_usertours\manager::get_current_tours() (MDL-69739).  By reflecting
this Moodle change local_navbarplus must now require Moodle 3.10.

Proposed fix for https://github.com/moodleuulm/moodle-local_navbarplus/issues/13 (revised again).