### PR TITLE
Explicitly add rel="noopener" when opening link in new window.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -135,6 +135,7 @@ function local_navbarplus_render_navbar_output() {
                 // If optional param for itemopeninnewwindow is set to true add a target=_blank to the link.
                 if ($itemopeninnewwindow) {
                     $linkattributes['target'] = '_blank';
+                    $linkattributes['rel'] = 'noopener';
                 }
                 // Define classes for all icons.
                 $itemclasses = 'localnavbarplus nav-link';


### PR DESCRIPTION
When opening a link in a new window, adding rel="noopener" prevents the new page from accessing the 'window.opener' property.

For more details, see: https://web.dev/external-anchors-use-rel-noopener/